### PR TITLE
Updated README.MD

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This Ansible playbook is based on the guide written by [Alex Elli](https://gist.
 To install the dependencies needed to run this playbook either :
 
 ```
-$ pip install -r requirments.txt
+$ pip install -r requirements.txt
 ```
 
 ## Building


### PR DESCRIPTION
There was a spelling error $ pip install -r requirements.txt was spelled $ pip install -r requirments.txt , although minor it makes it easier to copy and paste the code directly